### PR TITLE
[BUGFIX] Fix invalid format of delta (metric) value

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand"
+	"strconv"
 	"strings"
 )
 
@@ -33,8 +34,10 @@ func (g *Godspeed) Send(stat, kind string, delta, sampleRate float64, tags []str
 		buffer.WriteString(fmt.Sprintf("%v.", g.Namespace))
 	}
 
+	deltaStr := strconv.FormatFloat(delta, 'f', -1, 64)
+
 	// write the name of the metric to the byte buffer as well as the metric itself
-	buffer.WriteString(fmt.Sprintf("%v:%g|%v", string(trimReserved(stat)), delta, kind))
+	buffer.WriteString(fmt.Sprintf("%v:%v|%v", string(trimReserved(stat)), deltaStr, kind))
 
 	// if the sample rate is less than 1 add it too
 	if sampleRate < 1 {

--- a/stats_test.go
+++ b/stats_test.go
@@ -104,6 +104,29 @@ func TestSend(t *testing.T) {
 	}
 
 	//
+	// test whether sending a large metric works
+	//
+	err = g.Send("testing.metric", "g", 5536650702696, 1, nil)
+
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
+	a, ok = <-out
+
+	if !ok {
+		t.Error(closedChan)
+		return
+	}
+
+	b = []byte("testing.metric:5536650702696|g")
+
+	if !bytes.Equal(a, b) {
+		t.Error(noGo(a, b))
+	}
+
+	//
 	// test whether sending a metric with a sample rate works
 	//
 	err = g.Send("testing.metric", "ms", 256.512, 0.99, nil)


### PR DESCRIPTION
By default Golang will use a decimal exponent when converting larger float value to a string. This issue was not caught due to small values being used in testing.

This bug is fixed by explicitly converting the float64 value to a string and then specifying that we will not use exponential formatting. There is also a test added to catch this issue.
